### PR TITLE
Documents bug

### DIFF
--- a/app/controllers/chambers/documents_controller.rb
+++ b/app/controllers/chambers/documents_controller.rb
@@ -4,13 +4,13 @@ class Chambers::DocumentsController < ApplicationController
   def create
     document = Document.new(candidate_id: document_params[:candidate_id], document: document_params[:document],
        name: document_params[:name], description: document_params[:description], peer_id: peer.id)
+    candidate = Candidate.find(params['document']['candidate_id'])
     if document.save
-      flash[:success] = "Document Upload Successful"
-      candidate = Candidate.find(params['document']['candidate_id'])
-      redirect_to "#{chambers_candidate_path(candidate.order,candidate)}#documents"
+      flash[:success] = "Your document was uploaded successfully"
     else
-      flash[:error] = "Document Upload Unsuccessful: #{document.errors.full_messages.to_sentence}"
+      flash[:error] = "Your document was not able to be uploaded: #{document.errors.full_messages.to_sentence}"
     end
+      redirect_to "#{chambers_candidate_path(candidate.order,candidate)}#documents"
   end
   private
   def document_params

--- a/app/javascript/modules/showFileUploadName.js
+++ b/app/javascript/modules/showFileUploadName.js
@@ -1,0 +1,8 @@
+export default (() => {
+ $(document).ready(function(){
+   $('.custom-file-input').change(function(e){
+    var fileName = e.target.files[0].name;
+    $(`.custom-file-label[for=${e.currentTarget['id']}]`).html(fileName);
+   });
+ });
+})()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -36,6 +36,7 @@ import '../modules/gallery'
 import '../modules/tabSwitcher'
 import '../modules/hidePictures'
 import '../modules/pollAnalyticsTable'
+import '../modules/showFileUploadName'
 
 import fontawesome from '@fortawesome/fontawesome';
 import solid from '@fortawesome/fontawesome-free-solid';

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,6 +2,6 @@ class Document < ApplicationRecord
   belongs_to :peer
   belongs_to :candidate
 	has_one_attached :document
-  validates_presence_of :name
+  validates_presence_of :name, :document
 
 end

--- a/app/services/candidate_presenter.rb
+++ b/app/services/candidate_presenter.rb
@@ -1,6 +1,6 @@
 class CandidatePresenter
   extend Forwardable
-  def_delegators :@candidate, :sca_name, :comments, :profile_pic, :profile_pic_full, :profile_pic_thumb, :list, :group, :documents, :peerage_type, :id, :documents?
+  def_delegators :@candidate, :sca_name, :comments, :profile_pic, :profile_pic_full, :profile_pic_thumb, :list, :group, :peerage_type, :id 
   attr_reader :results
 
   def initialize(candidate:, results_picker: ResultsPicker.new)
@@ -19,7 +19,15 @@ class CandidatePresenter
   def poll_result?
     @results.present?
   end
-
+  def documents
+    @candidate.documents.select{|x| x.document.present? }
+  end
+  def documents?
+    documents.any?
+  end
+  def document_count
+    documents.count
+  end
   def poll_date
 		if poll_result?
       poll = @results.poll
@@ -44,9 +52,6 @@ class CandidatePresenter
     @candidate.advocacies.count > 0
   end
 
-  def document_count
-    @candidate.documents.count
-  end
   def comments
     @candidate.comments.sort_by(&:created_at)
   end

--- a/app/views/chambers/peerage/candidates/show.html.erb
+++ b/app/views/chambers/peerage/candidates/show.html.erb
@@ -49,9 +49,9 @@
             <% end %>
           <h3>Add an Image/Document</h3>
           <%= bootstrap_form_for @document, url: chambers_documents_path do |f| %>
-            <%= f.file_field :document, label: 'File' %>
+            <%= f.file_field :document, label: 'File', required: true %>
             <%= f.hidden_field :candidate_id, value: @candidate.id %>
-            <%= f.text_field :name %>
+            <%= f.text_field :name, required: true %>
             <%= f.text_field :description %>
             <%= f.submit %>
           <% end %> 

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,13 +1,13 @@
 {
-  "application.js": "/packs/js/application-c1254b91cbd54d043c84.js",
-  "application.js.map": "/packs/js/application-c1254b91cbd54d043c84.js.map",
+  "application.js": "/packs/js/application-e21ef067000c00ee1e61.js",
+  "application.js.map": "/packs/js/application-e21ef067000c00ee1e61.js.map",
   "entrypoints": {
     "application": {
       "js": [
-        "/packs/js/application-c1254b91cbd54d043c84.js"
+        "/packs/js/application-e21ef067000c00ee1e61.js"
       ],
       "js.map": [
-        "/packs/js/application-c1254b91cbd54d043c84.js.map"
+        "/packs/js/application-e21ef067000c00ee1e61.js.map"
       ]
     }
   }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,13 @@ FactoryBot.define do
     name { 'String' }
     association :peer, strategy: :build
     association :candidate, strategy: :build
+    after(:build) do |document|
+      document.document.attach(
+      io: File.open(Rails.root.join('spec', 'fixtures', 'test.jpg')),
+      filename: 'test.jpg',
+      content_type: 'image/jpeg'
+    )
+    end
   end
   factory :poll_result do
     association :candidate, strategy: :build

--- a/spec/requests/chambers/documents_spec.rb
+++ b/spec/requests/chambers/documents_spec.rb
@@ -1,33 +1,38 @@
 require "rails_helper"
 describe "post /chambers/documents" do
-  it "creates new document for candidate" do
-    document = FilesTestHelper.jpg
+  before(:each) do
     laurel = create(:laurel_peer)
     sign_in(laurel.user)
-    cand = create(:candidate)
+    @cand = create(:candidate)
+  end
+  it "creates new document for candidate" do
+    document = FilesTestHelper.jpg
     expect(Document.count).to eq(0)
-    post '/chambers/documents', params: { :document => {candidate_id: cand.id, document: document, name: 'Name', description: 'Description'} }
+    post '/chambers/documents', params: { :document => {candidate_id: @cand.id, document: document, name: 'Name', description: 'Description'} }
     expect(Document.count).to eq(1)
-    expect(response).to redirect_to("/chambers/laurel/candidates/#{cand.id}#documents")
+    expect(response).to redirect_to("/chambers/laurel/candidates/#{@cand.id}#documents")
   end
   it "creates new pdf for candidate" do
     document = FilesTestHelper.pdf
-    laurel = create(:laurel_peer)
-    sign_in(laurel.user)
-    cand = create(:candidate)
     expect(Document.count).to eq(0)
-    post '/chambers/documents', params: { :document => {candidate_id: cand.id, document: document, name: 'Name', description: 'Description'} }
+    post '/chambers/documents', params: { :document => {candidate_id: @cand.id, document: document, name: 'Name', description: 'Description'} }
     expect(Document.count).to eq(1)
-    expect(response).to redirect_to("/chambers/laurel/candidates/#{cand.id}#documents")
+    expect(response).to redirect_to("/chambers/laurel/candidates/#{@cand.id}#documents")
   end
   it "creates new docx for candidate" do
     document = FilesTestHelper.docx
-    laurel = create(:laurel_peer)
-    sign_in(laurel.user)
-    cand = create(:candidate)
     expect(Document.count).to eq(0)
-    post '/chambers/documents', params: { :document => {candidate_id: cand.id, document: document, name: 'Name', description: 'Description'} }
+    post '/chambers/documents', params: { :document => {candidate_id: @cand.id, document: document, name: 'Name', description: 'Description'} }
     expect(Document.count).to eq(1)
-    expect(response).to redirect_to("/chambers/laurel/candidates/#{cand.id}#documents")
+    expect(response).to redirect_to("/chambers/laurel/candidates/#{@cand.id}#documents")
+    follow_redirect!
+    expect(response.body).to include("was uploaded successfully")
+  end
+  it "show error when the document is invalid" do
+    post '/chambers/documents', params: { :document => {candidate_id: @cand.id, document: nil, name: 'Name', description: 'Description'} }
+    expect(Document.count).to eq(0)
+    expect(response).to redirect_to("/chambers/laurel/candidates/#{@cand.id}#documents")
+    follow_redirect!
+    expect(response.body).to include("was not able")
   end
 end

--- a/spec/services/candidate_presenter_spec.rb
+++ b/spec/services/candidate_presenter_spec.rb
@@ -1,192 +1,178 @@
 require 'rails_helper'
-describe CandidatePresenter, 'initialize' do
+describe CandidatePresenter do
   before(:each) do
     @laurel = create(:laurel_peer)
     @group = create(:group)
     @candidate = create(:laurel_candidate, group: @group)
     @comment = create(:comment, candidate: @candidate, peer: @laurel) 
     @document = create(:document, candidate: @candidate, peer: @laurel)
-    @presenter = CandidatePresenter.new(candidate: @candidate)
   end
-  it "shows candidate id" do
-    expect(@presenter.id).to eq(@candidate.id)
+  subject do
+    described_class.new(candidate: @candidate)
   end
-  it "shows peerage_type" do
-    expect(@presenter.peerage_type).to eq(@candidate.peerage_type)
-  end
-  it "shows sca_name" do
-    expect(@presenter.sca_name).to eq(@candidate.sca_name)
-  end
-  it "shows profile_pic" do
-    expect(@presenter.profile_pic).to eq(@candidate.profile_pic)
-  end
-  it "shows what list candidate is on" do
-    expect(@presenter.list).to eq(@candidate.list)
-  end
-  it "shows comments" do
-    expect(@presenter.comments.first).to eq(@comment)
-  end
-  it "shows group" do
-    expect(@presenter.group).to eq(@group)
-  end
-  it "shows document" do
-   expect(@presenter.documents&.first).to eq(@document)
-  end
-end
-describe CandidatePresenter, 'poll_result?' do
-  it 'returns true when there is a last published poll result' do
-    candidate = create(:candidate)
-    poll = create(:past_published_poll)
-    create(:poll_result, candidate: candidate, poll: poll)
-    presenter = CandidatePresenter.new( candidate: candidate)
-    
-    expect(presenter.poll_result?).to be_truthy 
-  end
-  it 'returns false when there is no last poll result' do
-    candidate = create(:candidate)
-    presenter = CandidatePresenter.new( candidate: candidate)
-    
-    expect(presenter.poll_result?).to be_falsey 
-  end
-end
-describe CandidatePresenter, 'document_count' do
-  before(:each) do
-    @candidate = create(:candidate)
-  end
-  it 'returns count of documents' do
-    document = create(:document, candidate:@candidate)
-    presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(presenter.document_count).to eq(1) 
-  end 
-  it 'returns 0 for no documents' do
-    presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(presenter.document_count).to eq(0) 
-  end
-end
-describe CandidatePresenter, 'specialties' do
- 
-  it "outputs string of specialties with appropriate linking" do
-    @candidate = create(:laurel_candidate, specialty_detail: 'Motets')
-    @specialty = create(:specialty, name: 'Music')
-    create(:specialization, candidate: @candidate, specialty: @specialty)
-    @presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(@presenter.specialties).to eq('<a href="/chambers/laurel/specialties/music">Music</a>, Motets')
-  end  
-  it "outputs no specialty_detail appropriately" do
-    @candidate = create(:laurel_candidate, specialty_detail: '')
-    @specialty = create(:specialty, name: 'Music')
-    create(:specialization, candidate: @candidate, specialty: @specialty)
-    @presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(@presenter.specialties).to eq('<a href="/chambers/laurel/specialties/music">Music</a>')
-  end
-end
-describe CandidatePresenter, 'specialties?' do
-    it 'returns true for exisitng specialties' do
-      candidate = create(:laurel_candidate, specialty_detail: 'Motets')
-      specialty = create(:specialty, name: 'Music')
-      create(:specialization, candidate: candidate, specialty: specialty)
-      presenter = CandidatePresenter.new( candidate: candidate)
-      expect(presenter.specialties?).to be_truthy
+  context "#initialize" do
+    it "shows candidate id" do
+      expect(subject.id).to eq(@candidate.id)
     end
-    it 'returns true for one specialty and no detail' do
-      candidate = create(:laurel_candidate, specialty_detail: nil)
-      specialty = create(:specialty, name: 'Music')
-      create(:specialization, candidate: candidate, specialty: specialty)
-      presenter = CandidatePresenter.new( candidate: candidate)
-      expect(presenter.specialties?).to be_truthy
+    it "shows peerage_type" do
+      expect(subject.peerage_type).to eq(@candidate.peerage_type)
     end
-    it 'returns true for specialty detail and no Specialty' do
-      candidate = create(:laurel_candidate, specialty_detail: 'Motets')
-      presenter = CandidatePresenter.new( candidate: candidate)
-      expect(presenter.specialties?).to be_truthy
+    it "shows sca_name" do
+      expect(subject.sca_name).to eq(@candidate.sca_name)
     end
-    it 'returns false for no specialty detail or Specialty'  do
-      candidate = create(:laurel_candidate, specialty_detail: nil)
-      presenter = CandidatePresenter.new( candidate: candidate)
-      expect(presenter.specialties?).to be_falsey
+    it "shows profile_pic" do
+      expect(subject.profile_pic).to eq(@candidate.profile_pic)
+    end
+    it "shows what list candidate is on" do
+      expect(subject.list).to eq(@candidate.list)
+    end
+    it "shows comments" do
+      expect(subject.comments.first).to eq(@comment)
+    end
+    it "shows group" do
+      expect(subject.group).to eq(@group)
+    end
+    it "shows document" do
+     expect(subject.documents&.first).to eq(@document)
+    end
+  end
+  context "#poll_result?" do
+    it 'returns true when there is a last published poll result' do
+      poll = create(:past_published_poll)
+      create(:poll_result, candidate: @candidate, poll: poll)
+      expect(subject.poll_result?).to be_truthy 
+    end
+    it 'returns false when there is no last poll result' do
+      expect(subject.poll_result?).to be_falsey 
+    end
+  end
+  context "#documents" do
+    it "returns non-nil documents" do
+      expect(subject.documents.count).to eq(1)
+    end
+    it "does not return nil documents" do
+      @document.document.purge
+      expect(subject.documents.count).to eq(0)
+    end
+  end
+  context "#documents?" do
+    it "returns non-nil documents" do
+      expect(subject.documents?).to eq(true)
+    end
+    it "does not return nil documents" do
+      @document.document.purge
+      expect(subject.documents?).to eq(false)
+    end
+  end
+  context "document_count" do
+    it 'returns count of documents' do
+      expect(subject.document_count).to eq(1) 
     end 
-end
-
-describe CandidatePresenter, 'advocates' do
-  before(:each) do
-    @candidate = create(:laurel_candidate) 
-    @laurel = create(:laurel_peer)
-    create(:advocacy, candidate: @candidate, peer: @laurel)
+    it 'returns 0 for no documents' do
+      @document.document.purge
+      expect(subject.document_count).to eq(0) 
+    end
   end
-  it "returns advocate as a link"  do
-    presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(presenter.advocates).to eq("<a href=\"/laurel/#{@laurel.slug}\">#{@laurel.sca_name}</a>")  
+  context "specialties" do
+    before(:each) do
+      specialty = create(:specialty, name: 'Music')
+      create(:specialization, candidate: @candidate, specialty: specialty)
+    end
+    context "#specialites" do
+      it "outputs string of specialties with appropriate linking" do
+        @candidate.update(specialty_detail: 'Motets')
+        expect(subject.specialties).to eq('<a href="/chambers/laurel/specialties/music">Music</a>, Motets')
+      end  
+      it "outputs no specialty_detail appropriately" do
+        expect(subject.specialties).to eq('<a href="/chambers/laurel/specialties/music">Music</a>')
+      end
+    end
+    context "#specialities?" do
+      it 'returns true for exisitng specialties' do
+        @candidate.update(specialty_detail: 'Motets')
+        expect(subject.specialties?).to be_truthy
+      end
+      it 'returns true for one specialty and no detail' do
+        expect(subject.specialties?).to be_truthy
+      end
+      it 'returns true for specialty detail and no Specialty' do
+        @candidate.update(specialty_detail: 'Motets')
+        Specialization.last.destroy
+        expect(subject.specialties?).to be_truthy
+      end
+      it 'returns false for no specialty detail or Specialty'  do
+        Specialization.last.destroy
+        expect(subject.specialties?).to be_falsey
+      end 
+    end
   end
-  it "returns advocates as links separated by ', '" do
-    laurel2 = create(:laurel_user, sca_name: 'Bob', slug: 'bob')
-    create(:advocacy, candidate: @candidate, peer: laurel2.laurel)
-    presenter = CandidatePresenter.new( candidate: @candidate)
-    expect(presenter.advocates).to eq("<a href=\"/laurel/#{@laurel.slug}\">#{@laurel.sca_name}</a>, <a href=\"/laurel/bob\">Bob</a>")  
+  context "advocates" do
+    before(:each) do
+      @laurel = create(:laurel_peer)
+      create(:advocacy, candidate: @candidate, peer: @laurel)
+    end
+    context "#advocates" do
+      it "returns advocate as a link"  do
+        expect(subject.advocates).to eq("<a href=\"/laurel/#{@laurel.slug}\">#{@laurel.sca_name}</a>")  
+      end
+      it "returns advocates as links separated by ', '" do
+        laurel2 = create(:laurel_user, sca_name: 'Bob', slug: 'bob')
+        create(:advocacy, candidate: @candidate, peer: laurel2.laurel)
+        expect(subject.advocates).to eq("<a href=\"/laurel/#{@laurel.slug}\">#{@laurel.sca_name}</a>, <a href=\"/laurel/bob\">Bob</a>")  
+      end
+    end
+    context "#advocates?" do
+      it "returns true if there are advocates" do
+        expect(subject.advocates?).to be_truthy 
+      end
+      it "returns false if there are no advocates" do
+        Advocacy.last.destroy
+        expect(subject.advocates?).to be_falsey 
+      end
+    end
   end
-end
-describe CandidatePresenter, 'advocates?' do
-  it "returns true if there are advocates" do
-    candidate = create(:laurel_candidate) 
-    laurel = create(:laurel_peer)
-    create(:advocacy, candidate: candidate, peer: laurel)
-    presenter = CandidatePresenter.new( candidate: candidate)
-   
-    expect(presenter.advocates?).to be_truthy 
+  context "last published poll results" do
+    before(:each) do
+      @poll = create(:past_published_poll) 
+      @poll_result = create(:poll_result, candidate: @candidate, poll: @poll, elevate: 1, wait:2, drop:3, no_strong_opinion: 4, rec: 0.399999, fav: 0.59999)
+    end
+    it "shows elevate" do
+      expect(subject.elevate).to eq(@poll_result.elevate)
+    end
+    it "shows wait" do
+      expect(subject.wait).to eq(@poll_result.wait)
+    end
+    it "drop" do
+      expect(subject.drop).to eq(@poll_result.drop)
+    end
+    it "shows no_strong_opinion" do
+      expect(subject.no_strong_opinion).to eq(@poll_result.no_strong_opinion)
+    end
+    it "rec" do
+      expect(subject.rec).to eq("40%")
+    end
+    it "fav" do
+      expect(subject.fav).to eq("60%")
+    end
   end
-  it "returns false if there are no advocates" do
-    candidate = create(:laurel_candidate) 
-    presenter = CandidatePresenter.new( candidate: candidate)
-   
-    expect(presenter.advocates?).to be_falsey 
-  end
-end
-describe CandidatePresenter, 'last published poll results' do
-  before(:each) do
-    @candidate = create(:laurel_candidate)     
-    @poll = create(:past_published_poll) 
-    @poll_result = create(:poll_result, candidate: @candidate, poll: @poll, elevate: 1, wait:2, drop:3, no_strong_opinion: 4, rec: 0.399999, fav: 0.59999)
-    @presenter = CandidatePresenter.new( candidate: @candidate)
-  end
-  it "shows elevate" do
-    expect(@presenter.elevate).to eq(@poll_result.elevate)
-  end
-  it "shows wait" do
-    expect(@presenter.wait).to eq(@poll_result.wait)
-  end
-  it "drop" do
-    expect(@presenter.drop).to eq(@poll_result.drop)
-  end
-  it "shows no_strong_opinion" do
-    expect(@presenter.no_strong_opinion).to eq(@poll_result.no_strong_opinion)
-  end
-  it "rec" do
-    expect(@presenter.rec).to eq("40%")
-  end
-  it "fav" do
-    expect(@presenter.fav).to eq("60%")
-  end
-end
-describe CandidatePresenter, 'last poll results for no polls' do
-  before(:each) do
-    @candidate = create(:laurel_candidate)     
-    @presenter = CandidatePresenter.new( candidate: @candidate)
-  end
-  it "shows elevate" do
-    expect(@presenter.elevate).to eq('')
-  end
-  it "shows wait" do
-    expect(@presenter.wait).to eq('')
-  end
-  it "drop" do
-    expect(@presenter.drop).to eq('')
-  end
-  it "shows no_strong_opinion" do
-    expect(@presenter.no_strong_opinion).to eq('')
-  end
-  it "rec" do
-    expect(@presenter.rec).to eq('')
-  end
-  it "fav" do
-    expect(@presenter.fav).to eq('')
+  context "last published poll results for no polls" do
+    it "shows elevate" do
+      expect(subject.elevate).to eq('')
+    end
+    it "shows wait" do
+      expect(subject.wait).to eq('')
+    end
+    it "drop" do
+      expect(subject.drop).to eq('')
+    end
+    it "shows no_strong_opinion" do
+      expect(subject.no_strong_opinion).to eq('')
+    end
+    it "rec" do
+      expect(subject.rec).to eq('')
+    end
+    it "fav" do
+      expect(subject.fav).to eq('')
+    end
   end
 end


### PR DESCRIPTION
Fixes the bug with being able to upload invalid documents by:
* changing candidate presenter to only show non-nil documents
* changing document to require that the file be present
* changing the form to require the file and name fields before validation
* showing the name of the uploaded file once it's been loaded